### PR TITLE
Create releases from github actions on new tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '[0-9]+\.[0-9]+\.[0-9]+'
+
+jobs:
+  package:
+    if: github.event.base_ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build package
+        run: make dist
+
+      - name: Get version
+        id: version
+        shell: bash
+        run: echo "::set-output name=name::$(cat VERSION)"
+
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.version.outputs.name }}
+          release_name: Release ${{ steps.version.outputs.name }}
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./cardbackup-${{ steps.version.outputs.name }}.tar.gz
+          asset_name: cardbackup-${{ steps.version.outputs.name }}.tar.gz
+          asset_content_type: application/gzip

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean:
 
 distclean: clean
 	rm -f VERSION
-	rm cardbackup-*.tar.gz
+	rm -f cardbackup-*.tar.gz
 
 dist: all $(PKG_FILE)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ```
 
 ![language badge](https://img.shields.io/github/languages/top/vincent-peugnet/cardbackup?color=green)
+[![latest release](https://img.shields.io/github/v/release/vincent-peugnet/cardbackup)](https://github.com/vincent-peugnet/cardbackup/releases/latest)
 
 Card BackUp is the only good thing that came up in 2020.
 
@@ -63,6 +64,14 @@ A summary of the copy is displayed in your shell, indicating which files were co
 
 It will analyse the copied card using mediainfo to create a little log and take some screenshots of the video files. A PDF is generated containing media infos of files and 3 screens per video file.
 
+## Create a release
+
+```bash
+# Releases must be created on master branch
+git checkout master
+git tag x.x.x
+git push --tags
+```
 
 ## To Do
 


### PR DESCRIPTION
### Goal

This way to create a release you just have to create a tag in git and push it to GitHub. The `release` action then creates a new _Release_ on GitHub based on the name of the tag, builds the `.tar.gz` package and add it to the release.

Once this is merged you can release the first version this way:

    git switch master
    git pull
    git tag 1.0.0
    git push --tags

### Content

- add github action release.yml
- add instruction for releases and badge in readme
- fix make file distclean target