### PR TITLE
fix: incorrect duration calculation

### DIFF
--- a/bin/analyse
+++ b/bin/analyse
@@ -85,7 +85,7 @@ bit depth          : $BitDepthString" | tee -a "$TMP_DIR/summary.tex"
     screenquality="-vf scale=1280:-1 -q:v 5"
     echo $md5
 
-    let "d = $Duration"
+    let "d = ${Duration%.*}"
     let "d = d / 1000"
     let "m = d / 2"
     let "l = d - 1"


### PR DESCRIPTION
caused by:
/usr/local/bin/analyse: line 88: let: d = 1514346.000000: syntax error: invalid arithmetic operator (error token is .000000)

fixed by trimming the decimal part
